### PR TITLE
Fix library link

### DIFF
--- a/breakout-boards/mx/fp-lib-table
+++ b/breakout-boards/mx/fp-lib-table
@@ -1,0 +1,4 @@
+(fp_lib_table
+  (lib (name ultraboard)(type KiCad)(uri ${ULTRABOARD_DIR}/ultraboard-kicad/ultraboard.pretty)(options "")(descr ""))
+  (lib (name ultraboard-img)(type KiCad)(uri ${ULTRABOARD_DIR}/ultraboard-kicad/img.pretty)(options "")(descr ""))
+)

--- a/breakout-boards/mx/sym-lib-table
+++ b/breakout-boards/mx/sym-lib-table
@@ -1,0 +1,3 @@
+(sym_lib_table
+  (lib (name ultraboard_lib)(type Legacy)(uri ${ULTRABOARD_DIR}/ultraboard-kicad/ultraboard_lib.lib)(options "")(descr ""))
+)


### PR DESCRIPTION
(#4) Creates local library tables for both the schematic and footprint. all that needs to be edited on the user side is the path variables